### PR TITLE
#17: enable XMPP ping

### DIFF
--- a/bots/jabber.js
+++ b/bots/jabber.js
@@ -68,4 +68,23 @@ function send({name, message}) {
   );
 }
 
+if (chat.pingMs) {
+  const jid = config.connection.jid.toString();
+  const server = new xmpp.JID(jid).getDomain();
+
+  let pingCounter = 0;
+  const schedulePing = () => {
+    const iq = new xmpp.Element('iq', {
+      type: 'get',
+      to: server,
+      from: jid,
+      id: `ping${pingCounter++}`
+    }).c('ping', {xmlns: 'urn:xmpp:ping'});
+    client.send(iq);
+
+    setTimeout(schedulePing, chat.pingMs);
+  };
+  schedulePing();
+}
+
 module.exports = {client, send};

--- a/sample-config.json
+++ b/sample-config.json
@@ -7,11 +7,13 @@
     },
     "dev": {
       "room": "bimo_test@conference.jabber.ru",
-      "nick": "tg"
+      "nick": "tg",
+      "pingMs": 60000
     },
     "prod": {
       "room": "javascript@conference.jabber.ru",
-      "nick": "tg"
+      "nick": "tg",
+      "pingMs": 60000
     }
   },
   "telegram": {


### PR DESCRIPTION
This enables [XEP-0199](http://xmpp.org/extensions/xep-0199.html) support. Just set up `pingMs` in config, and bot will send pings to server with that interval.