### PR TITLE
eslint: disable linebreak-style

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "rules": {
       "camelcase": ["error", {"properties": "never"}],
       "import/no-unresolved": [0],
-      "import/no-unassigned-import": [0]
+      "import/no-unassigned-import": [0],
+      "linebreak-style": 0
     },
     "space": true,
     "semicolon": true


### PR DESCRIPTION
This disables `linebreak-style` eslint check.

The reason I suggest that change is that I have `git config core.autocrlf` set to `true` on my local system. That means that all my local files have `CRLF` in them, although they will be commited with the proper settings (`LF` only), and I don't want to change that.

If that PR won't be accepted, that'll make further contribution slightly inconvenient for me.