### PR TITLE
Telegram: write nick of original author in braces

### DIFF
--- a/bots/telegram/client.js
+++ b/bots/telegram/client.js
@@ -43,8 +43,8 @@ class ReplyToMessage extends Message {
 
   getDetails() {
     const msg = this.msg;
-    const nick = Name.from(msg.from);
     const replyToMessage = msg.reply_to_message;
+    const nick = Name.from(replyToMessage.from);
     const message = replyToMessage.text;
 
     return [nick, message];


### PR DESCRIPTION
Without that bugfix, replies are always quoted with nickname of the user who quoted someone. E.g.

```
<@fvnever> >> <fvnever> You suck
```

instead of

```
<@fvnever> >> <somebody> You suck
```
