### PR TITLE
Remove stopped demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ $ node ./node_modules/husky/bin/install.js
 ### Discussion
 
 - dev-chat: [@chat_linker](https://t.me/chat_linker) (RU)
-- demo telegram-side: [@javascript_ru](https://t.me/javascript_ru) (RU)
-- demo XMPP-side: [javascript@conference.jabber.ru](xmpp://javascript@conference.jabber.ru?join) (RU)
 
 
 [bots-docs]: https://core.telegram.org/bots#3-how-do-i-create-a-bot


### PR DESCRIPTION
I suggest we remove incorrect information from the README. We no longer provide the bot service in javascript@cjr.